### PR TITLE
Increased stack memory for microbit

### DIFF
--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -74,7 +74,7 @@ static mut PROCESS_PRINTER: Option<&'static kernel::process::ProcessPrinterText>
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
 #[link_section = ".stack_buffer"]
-pub static mut STACK_MEMORY: [u8; 0x1099] = [0; 0x1099];
+pub static mut STACK_MEMORY: [u8; 0x1100] = [0; 0x1100];
 // debug mode requires more stack space
 // pub static mut STACK_MEMORY: [u8; 0x2000] = [0; 0x2000];
 

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -74,7 +74,7 @@ static mut PROCESS_PRINTER: Option<&'static kernel::process::ProcessPrinterText>
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
 #[link_section = ".stack_buffer"]
-pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
+pub static mut STACK_MEMORY: [u8; 0x1099] = [0; 0x1099];
 // debug mode requires more stack space
 // pub static mut STACK_MEMORY: [u8; 0x2000] = [0; 0x2000];
 


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the stack memory needed for the Process Console on the microbit board. The command `process n` caused a stack overflow which panics the kernel. The value was obtained by slowly incrementing the stack memory until the command `process n` didn't cause a stack overflow so that it would be the minimum necessary. 
I have attached the [output of the command](https://github.com/UPB-CS-OpenSourceUpstream/tock/files/10120932/process.blink.stack.overflow.txt).


### TODO 


This pull request still needs some testing on other microbit boards to be sure that the kernel panic wasn't caused by faulty equipment.

