### PR TITLE
Made the set_clocks functions public to crates only

### DIFF
--- a/chips/rp2040/src/spi.rs
+++ b/chips/rp2040/src/spi.rs
@@ -288,7 +288,7 @@ impl<'a> Spi<'a> {
         }
     }
 
-    pub fn set_clocks(&self, clocks: &'a clocks::Clocks) {
+    pub(crate) fn set_clocks(&self, clocks: &'a clocks::Clocks) {
         self.clocks.set(clocks);
     }
 

--- a/chips/rp2040/src/uart.rs
+++ b/chips/rp2040/src/uart.rs
@@ -439,7 +439,7 @@ impl<'a> Uart<'a> {
         }
     }
 
-    pub fn set_clocks(&self, clocks: &'a clocks::Clocks) {
+    pub(crate) fn set_clocks(&self, clocks: &'a clocks::Clocks) {
         self.clocks.set(clocks);
     }
 


### PR DESCRIPTION
### Pull Request Overview

The `set_clocks` functions from the RP2040 drivers are defined as public. They should be defined as public only for the crate to be more secure.
This pull request addresses that issue.

### TODO or Help Wanted

This pull request still needs code review.


### Documentation Updated

- No updates are required.

### Formatting

- [x] Ran `make prepush`.
