### PR TITLE
process_console command history

### DIFF
--- a/.lcignore
+++ b/.lcignore
@@ -8,7 +8,7 @@
 
 # TODO: This disables the license checker over most of the repository, enabling
 # it on a handful of files for demonstration purposes. The next few lines should
-# be removed when license headers are removed.
+# be removed when license headers are added.
 *
 !/.lcignore
 !/tools/

--- a/.lcignore
+++ b/.lcignore
@@ -1,0 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2022
+# Copyright Google LLC 2022
+
+/.git/
+*.md

--- a/.lcignore
+++ b/.lcignore
@@ -5,3 +5,12 @@
 
 /.git/
 *.md
+
+# TODO: This disables the license checker over most of the repository, enabling
+# it on a handful of files for demonstration purposes. The next few lines should
+# be removed when license headers are removed.
+*
+!/.lcignore
+!/tools/
+!/tools/license-checker/
+!/tools/license-checker/**

--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,9 @@ allstack stack stack-analysis:
 		do $(MAKE) --no-print-directory -C "boards/$$f" stack-analysis || exit 1;\
 		done
 
+.PHONY: licensecheck
+licensecheck:
+	@cargo run --manifest-path=tools/license-checker/Cargo.toml --release
 
 ## Commands
 .PHONY: clean
@@ -209,7 +212,8 @@ ci-nosetup:
 prepush:\
 	format\
 	ci-job-clippy\
-	ci-job-syntax
+	ci-job-syntax\
+	licensecheck
 	$(call banner,Pre-Push checks all passed!)
 	# Note: Tock runs additional and more intense CI checks on all PRs.
 	# If one of these error, you can run `make ci-job-NAME` to test locally.
@@ -334,7 +338,7 @@ ci-runner-netlify:\
 
 ### ci-runner-github-format jobs:
 .PHONY: ci-job-format
-ci-job-format:
+ci-job-format: licensecheck
 	$(call banner,CI-Job: Format Check)
 	@NOWARNINGS=true TOCK_FORMAT_MODE=diff $(MAKE) format
 
@@ -475,7 +479,7 @@ ci-setup-tools:
 define ci_job_tools
 	$(call banner,CI-Job: Tools)
 	@NOWARNINGS=true RUSTFLAGS="-D warnings" \
-		cargo build --all-targets --manifest-path=tools/Cargo.toml --workspace || exit 1
+		cargo test --all-targets --manifest-path=tools/Cargo.toml --workspace || exit 1
 endef
 
 .PHONY: ci-job-tools

--- a/boards/components/src/debug_writer.rs
+++ b/boards/components/src/debug_writer.rs
@@ -31,66 +31,79 @@ use kernel::hil::uart;
 // least a 1 KiB boundary). This is not _semantically_ critical, but helps keep buffers on 1 KiB
 // boundaries in some cases. Of course, these definitions are only advisory, and individual boards
 // can choose to pass in their own buffers with different lengths.
-pub const DEBUG_BUFFER_KBYTE: usize = 1;
+pub const DEFAULT_DEBUG_BUFFER_KBYTE: usize = 1;
 
 // Bytes [0, DEBUG_BUFFER_SPLIT) are used for output_buf while bytes
-// [DEBUG_BUFFER_SPLIT, DEBUG_BUFFER_KBYTE * 1024) are used for internal_buf.
+// [DEBUG_BUFFER_SPLIT, DEFAULT_DEBUG_BUFFER_KBYTE * 1024) are used for internal_buf.
 const DEBUG_BUFFER_SPLIT: usize = 64;
 
+/// The optional argument to this macro allows boards to specify the size of the in-RAM
+/// buffer used for storing debug messages. Increase this value to be able to send more debug
+/// messages in quick succession.
 #[macro_export]
 macro_rules! debug_writer_component_static {
-    () => {{
-        use $crate::debug_writer::DEBUG_BUFFER_KBYTE;
-
+    ($BUF_SIZE_KB:expr) => {{
         let uart = kernel::static_buf!(capsules::virtual_uart::UartDevice);
         let ring = kernel::static_buf!(kernel::collections::ring_buffer::RingBuffer<'static, u8>);
-        let buffer = kernel::static_buf!([u8; 1024 * DEBUG_BUFFER_KBYTE]);
+        let buffer = kernel::static_buf!([u8; 1024 * $BUF_SIZE_KB]);
         let debug = kernel::static_buf!(kernel::debug::DebugWriter);
         let debug_wrapper = kernel::static_buf!(kernel::debug::DebugWriterWrapper);
 
         (uart, ring, buffer, debug, debug_wrapper)
     };};
+    () => {{
+        $crate::debug_writer_component_static!($crate::debug_writer::DEFAULT_DEBUG_BUFFER_KBYTE)
+    };};
 }
 
+/// The optional argument to this macro allows boards to specify the size of the in-RAM
+/// buffer used for storing debug messages. Increase this value to be able to send more debug
+/// messages in quick succession.
 #[macro_export]
 macro_rules! debug_writer_no_mux_component_static {
-    () => {{
-        use $crate::debug_writer::DEBUG_BUFFER_KBYTE;
-
+    ($BUF_SIZE_KB:expr) => {{
         let ring = kernel::static_buf!(kernel::collections::ring_buffer::RingBuffer<'static, u8>);
-        let buffer = kernel::static_buf!([u8; 1024 * DEBUG_BUFFER_KBYTE]);
+        let buffer = kernel::static_buf!([u8; 1024 * $BUF_SIZE_KB]);
         let debug = kernel::static_buf!(kernel::debug::DebugWriter);
         let debug_wrapper = kernel::static_buf!(kernel::debug::DebugWriterWrapper);
 
         (ring, buffer, debug, debug_wrapper)
     };};
+    () => {{
+        use $crate::debug_writer::DEFAULT_DEBUG_BUFFER_KBYTE;
+        $crate::debug_writer_no_mux_component_static!(DEFAULT_DEBUG_BUFFER_KBYTE);
+    };};
 }
 
-pub struct DebugWriterComponent {
+pub struct DebugWriterComponent<const BUF_SIZE_BYTES: usize> {
     uart_mux: &'static MuxUart<'static>,
+    marker: core::marker::PhantomData<[u8; BUF_SIZE_BYTES]>,
 }
 
-impl DebugWriterComponent {
-    pub fn new(uart_mux: &'static MuxUart) -> DebugWriterComponent {
-        DebugWriterComponent { uart_mux: uart_mux }
+impl<const BUF_SIZE_BYTES: usize> DebugWriterComponent<BUF_SIZE_BYTES> {
+    pub fn new(uart_mux: &'static MuxUart) -> Self {
+        Self {
+            uart_mux,
+            marker: core::marker::PhantomData,
+        }
     }
 }
 
 pub struct Capability;
 unsafe impl capabilities::ProcessManagementCapability for Capability {}
 
-impl Component for DebugWriterComponent {
+impl<const BUF_SIZE_BYTES: usize> Component for DebugWriterComponent<BUF_SIZE_BYTES> {
     type StaticInput = (
         &'static mut MaybeUninit<UartDevice<'static>>,
         &'static mut MaybeUninit<RingBuffer<'static, u8>>,
-        &'static mut MaybeUninit<[u8; 1024 * DEBUG_BUFFER_KBYTE]>,
+        &'static mut MaybeUninit<[u8; BUF_SIZE_BYTES]>,
         &'static mut MaybeUninit<kernel::debug::DebugWriter>,
         &'static mut MaybeUninit<kernel::debug::DebugWriterWrapper>,
     );
     type Output = ();
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        let buf = s.2.write([0; 1024 * DEBUG_BUFFER_KBYTE]);
+        let buf = s.2.write([0; BUF_SIZE_BYTES]);
 
         let (output_buf, internal_buf) = buf.split_at_mut(DEBUG_BUFFER_SPLIT);
 
@@ -112,29 +125,38 @@ impl Component for DebugWriterComponent {
     }
 }
 
-pub struct DebugWriterNoMuxComponent<U: uart::Uart<'static> + uart::Transmit<'static> + 'static> {
+pub struct DebugWriterNoMuxComponent<
+    U: uart::Uart<'static> + uart::Transmit<'static> + 'static,
+    const BUF_SIZE_BYTES: usize,
+> {
     uart: &'static U,
+    marker: core::marker::PhantomData<[u8; BUF_SIZE_BYTES]>,
 }
 
-impl<U: uart::Uart<'static> + uart::Transmit<'static> + 'static> DebugWriterNoMuxComponent<U> {
+impl<U: uart::Uart<'static> + uart::Transmit<'static> + 'static, const BUF_SIZE_BYTES: usize>
+    DebugWriterNoMuxComponent<U, BUF_SIZE_BYTES>
+{
     pub fn new(uart: &'static U) -> Self {
-        Self { uart }
+        Self {
+            uart,
+            marker: core::marker::PhantomData,
+        }
     }
 }
 
-impl<U: uart::Uart<'static> + uart::Transmit<'static> + 'static> Component
-    for DebugWriterNoMuxComponent<U>
+impl<U: uart::Uart<'static> + uart::Transmit<'static> + 'static, const BUF_SIZE_BYTES: usize>
+    Component for DebugWriterNoMuxComponent<U, BUF_SIZE_BYTES>
 {
     type StaticInput = (
         &'static mut MaybeUninit<RingBuffer<'static, u8>>,
-        &'static mut MaybeUninit<[u8; 1024 * DEBUG_BUFFER_KBYTE]>,
+        &'static mut MaybeUninit<[u8; BUF_SIZE_BYTES]>,
         &'static mut MaybeUninit<kernel::debug::DebugWriter>,
         &'static mut MaybeUninit<kernel::debug::DebugWriterWrapper>,
     );
     type Output = ();
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        let buf = s.1.write([0; 1024 * DEBUG_BUFFER_KBYTE]);
+        let buf = s.1.write([0; BUF_SIZE_BYTES]);
         let (output_buf, internal_buf) = buf.split_at_mut(DEBUG_BUFFER_SPLIT);
 
         // Create virtual device for kernel debug.

--- a/boards/components/src/debug_writer.rs
+++ b/boards/components/src/debug_writer.rs
@@ -31,7 +31,7 @@ use kernel::hil::uart;
 // least a 1 KiB boundary). This is not _semantically_ critical, but helps keep buffers on 1 KiB
 // boundaries in some cases. Of course, these definitions are only advisory, and individual boards
 // can choose to pass in their own buffers with different lengths.
-pub const DEFAULT_DEBUG_BUFFER_KBYTE: usize = 1;
+pub const DEFAULT_DEBUG_BUFFER_KBYTE: usize = 2;
 
 // Bytes [0, DEBUG_BUFFER_SPLIT) are used for output_buf while bytes
 // [DEBUG_BUFFER_SPLIT, DEFAULT_DEBUG_BUFFER_KBYTE * 1024) are used for internal_buf.

--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -41,8 +41,8 @@ macro_rules! process_console_component_static {
         let queue_buffer = kernel::static_buf!([u8; capsules::process_console::QUEUE_BUF_LEN]);
         let command_buffer = kernel::static_buf!([u8; capsules::process_console::COMMAND_BUF_LEN]);
         let command_history_buffer = kernel::static_buf!(
-            [capsules::process_console::Command<{ capsules::process_console::COMMAND_BUF_LEN }>;
-                capsules::process_console::COMMAND_HISTORY_LEN]
+            [capsules::process_console::Command;
+                capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN]
         );
 
         (
@@ -107,8 +107,8 @@ impl<A: 'static + Alarm<'static>> Component for ProcessConsoleComponent<A> {
         &'static mut MaybeUninit<[u8; capsules::process_console::QUEUE_BUF_LEN]>,
         &'static mut MaybeUninit<[u8; capsules::process_console::COMMAND_BUF_LEN]>,
         &'static mut MaybeUninit<
-            [capsules::process_console::Command<{ capsules::process_console::COMMAND_BUF_LEN }>;
-                capsules::process_console::COMMAND_HISTORY_LEN],
+            [capsules::process_console::Command;
+                capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN],
         >,
         &'static mut MaybeUninit<ProcessConsole<'static, VirtualMuxAlarm<'static, A>, Capability>>,
     );
@@ -154,8 +154,8 @@ impl<A: 'static + Alarm<'static>> Component for ProcessConsoleComponent<A> {
             .5
             .write([0; capsules::process_console::COMMAND_BUF_LEN]);
         let command_history_buffer = static_buffer.6.write(
-            [capsules::process_console::Command::<{ capsules::process_console::COMMAND_BUF_LEN }>::new();
-                capsules::process_console::COMMAND_HISTORY_LEN],
+            [capsules::process_console::Command::new();
+                capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN],
         );
 
         let console = static_buffer.7.write(ProcessConsole::new(

--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -26,7 +26,7 @@ use kernel::process::ProcessPrinter;
 
 #[macro_export]
 macro_rules! process_console_component_static {
-    ($A: ty $(,)?, $COMMAND_HISTORY_LEN: expr) => {{
+    ($A: ty, $COMMAND_HISTORY_LEN: expr $(,)?) => {{
         let alarm = kernel::static_buf!(capsules::virtual_alarm::VirtualMuxAlarm<'static, $A>);
         let uart = kernel::static_buf!(capsules::virtual_uart::UartDevice);
         let pconsole = kernel::static_buf!(

--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -165,7 +165,7 @@ impl<const COMMAND_HISTORY_LEN: usize, A: 'static + Alarm<'static>> Component
             .write([0; capsules::process_console::COMMAND_BUF_LEN]);
         let command_history_buffer = static_buffer
             .6
-            .write([capsules::process_console::Command::new(); COMMAND_HISTORY_LEN]);
+            .write([capsules::process_console::Command::default(); COMMAND_HISTORY_LEN]);
 
         let console = static_buffer.7.write(ProcessConsole::new(
             console_uart,

--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -73,7 +73,7 @@ macro_rules! process_console_component_static {
         let queue_buffer = kernel::static_buf!([u8; capsules::process_console::QUEUE_BUF_LEN]);
         let command_buffer = kernel::static_buf!([u8; capsules::process_console::COMMAND_BUF_LEN]);
         let command_history_buffer = kernel::static_buf!(
-            [capsules::process_console::Command; capsules::process_console::$COMMAND_HISTORY_LEN]
+            [capsules::process_console::Command; $COMMAND_HISTORY_LEN]
         );
 
         (

--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -165,7 +165,7 @@ impl<const COMMAND_HISTORY_LEN: usize, A: 'static + Alarm<'static>> Component
             .write([0; capsules::process_console::COMMAND_BUF_LEN]);
         let command_history_buffer = static_buffer
             .6
-            .write([Default::default(); COMMAND_HISTORY_LEN]);
+            .write([capsules::process_console::Command::default(); COMMAND_HISTORY_LEN]);
 
         let console = static_buffer.7.write(ProcessConsole::new(
             console_uart,

--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -26,38 +26,7 @@ use kernel::process::ProcessPrinter;
 
 #[macro_export]
 macro_rules! process_console_component_static {
-    ($A: ty $(,)?) => {{
-        let alarm = kernel::static_buf!(capsules::virtual_alarm::VirtualMuxAlarm<'static, $A>);
-        let uart = kernel::static_buf!(capsules::virtual_uart::UartDevice);
-        let pconsole = kernel::static_buf!(
-            capsules::process_console::ProcessConsole<
-                { capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN },
-                capsules::virtual_alarm::VirtualMuxAlarm<'static, $A>,
-                components::process_console::Capability,
-            >
-        );
-
-        let write_buffer = kernel::static_buf!([u8; capsules::process_console::WRITE_BUF_LEN]);
-        let read_buffer = kernel::static_buf!([u8; capsules::process_console::READ_BUF_LEN]);
-        let queue_buffer = kernel::static_buf!([u8; capsules::process_console::QUEUE_BUF_LEN]);
-        let command_buffer = kernel::static_buf!([u8; capsules::process_console::COMMAND_BUF_LEN]);
-        let command_history_buffer = kernel::static_buf!(
-            [capsules::process_console::Command;
-                capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN]
-        );
-
-        (
-            alarm,
-            uart,
-            write_buffer,
-            read_buffer,
-            queue_buffer,
-            command_buffer,
-            command_history_buffer,
-            pconsole,
-        )
-    };};
-    ($A: ty $(,)?, $COMMAND_HISTORY_LEN: literal) => {{
+    ($A: ty $(,)?, $COMMAND_HISTORY_LEN: expr) => {{
         let alarm = kernel::static_buf!(capsules::virtual_alarm::VirtualMuxAlarm<'static, $A>);
         let uart = kernel::static_buf!(capsules::virtual_uart::UartDevice);
         let pconsole = kernel::static_buf!(
@@ -86,6 +55,9 @@ macro_rules! process_console_component_static {
             command_history_buffer,
             pconsole,
         )
+    };};
+    ($A: ty $(,)?) => {{
+        $crate::process_console_component_static!($A, { capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN })
     };};
 }
 

--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -14,7 +14,7 @@
 // Author: Philip Levis <pal@cs.stanford.edu>
 // Last modified: 6/20/2018
 
-use capsules::process_console::{self, ProcessConsole};
+use capsules::process_console::{self, Command, ProcessConsole};
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules::virtual_uart::{MuxUart, UartDevice};
 use core::mem::MaybeUninit;
@@ -41,7 +41,7 @@ macro_rules! process_console_component_static {
         let queue_buffer = kernel::static_buf!([u8; capsules::process_console::QUEUE_BUF_LEN]);
         let command_buffer = kernel::static_buf!([u8; capsules::process_console::COMMAND_BUF_LEN]);
         let command_history_buffer = kernel::static_buf!(
-            [[u8; capsules::process_console::COMMAND_BUF_LEN];
+            [Command<{ capsules::process_console::COMMAND_BUF_LEN }>;
                 capsules::process_console::COMMAND_HISTORY_LEN]
         );
 
@@ -107,7 +107,7 @@ impl<A: 'static + Alarm<'static>> Component for ProcessConsoleComponent<A> {
         &'static mut MaybeUninit<[u8; capsules::process_console::QUEUE_BUF_LEN]>,
         &'static mut MaybeUninit<[u8; capsules::process_console::COMMAND_BUF_LEN]>,
         &'static mut MaybeUninit<
-            [[u8; capsules::process_console::COMMAND_BUF_LEN];
+            [Command<{ capsules::process_console::COMMAND_BUF_LEN }>;
                 capsules::process_console::COMMAND_HISTORY_LEN],
         >,
         &'static mut MaybeUninit<ProcessConsole<'static, VirtualMuxAlarm<'static, A>, Capability>>,
@@ -154,7 +154,7 @@ impl<A: 'static + Alarm<'static>> Component for ProcessConsoleComponent<A> {
             .5
             .write([0; capsules::process_console::COMMAND_BUF_LEN]);
         let command_history_buffer = static_buffer.6.write(
-            [[0; capsules::process_console::COMMAND_BUF_LEN];
+            [Command::<{ capsules::process_console::COMMAND_BUF_LEN }>::new();
                 capsules::process_console::COMMAND_HISTORY_LEN],
         );
 

--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -165,7 +165,7 @@ impl<const COMMAND_HISTORY_LEN: usize, A: 'static + Alarm<'static>> Component
             .write([0; capsules::process_console::COMMAND_BUF_LEN]);
         let command_history_buffer = static_buffer
             .6
-            .write([capsules::process_console::Command::default(); COMMAND_HISTORY_LEN]);
+            .write([Default::default(); COMMAND_HISTORY_LEN]);
 
         let console = static_buffer.7.write(ProcessConsole::new(
             console_uart,

--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -73,9 +73,9 @@ impl<A: 'static + Alarm<'static>> ProcessConsoleComponent<A> {
         process_printer: &'static dyn ProcessPrinter,
     ) -> ProcessConsoleComponent<A> {
         ProcessConsoleComponent {
-            board_kernel: board_kernel,
-            uart_mux: uart_mux,
-            alarm_mux: alarm_mux,
+            board_kernel,
+            uart_mux,
+            alarm_mux,
             process_printer,
         }
     }

--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -14,7 +14,7 @@
 // Author: Philip Levis <pal@cs.stanford.edu>
 // Last modified: 6/20/2018
 
-use capsules::process_console::{self, Command, ProcessConsole};
+use capsules::process_console::{self, ProcessConsole};
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules::virtual_uart::{MuxUart, UartDevice};
 use core::mem::MaybeUninit;
@@ -41,7 +41,7 @@ macro_rules! process_console_component_static {
         let queue_buffer = kernel::static_buf!([u8; capsules::process_console::QUEUE_BUF_LEN]);
         let command_buffer = kernel::static_buf!([u8; capsules::process_console::COMMAND_BUF_LEN]);
         let command_history_buffer = kernel::static_buf!(
-            [Command<{ capsules::process_console::COMMAND_BUF_LEN }>;
+            [capsules::process_console::Command<{ capsules::process_console::COMMAND_BUF_LEN }>;
                 capsules::process_console::COMMAND_HISTORY_LEN]
         );
 
@@ -107,7 +107,7 @@ impl<A: 'static + Alarm<'static>> Component for ProcessConsoleComponent<A> {
         &'static mut MaybeUninit<[u8; capsules::process_console::QUEUE_BUF_LEN]>,
         &'static mut MaybeUninit<[u8; capsules::process_console::COMMAND_BUF_LEN]>,
         &'static mut MaybeUninit<
-            [Command<{ capsules::process_console::COMMAND_BUF_LEN }>;
+            [capsules::process_console::Command<{ capsules::process_console::COMMAND_BUF_LEN }>;
                 capsules::process_console::COMMAND_HISTORY_LEN],
         >,
         &'static mut MaybeUninit<ProcessConsole<'static, VirtualMuxAlarm<'static, A>, Capability>>,
@@ -154,7 +154,7 @@ impl<A: 'static + Alarm<'static>> Component for ProcessConsoleComponent<A> {
             .5
             .write([0; capsules::process_console::COMMAND_BUF_LEN]);
         let command_history_buffer = static_buffer.6.write(
-            [Command::<{ capsules::process_console::COMMAND_BUF_LEN }>::new();
+            [capsules::process_console::Command::<{ capsules::process_console::COMMAND_BUF_LEN }>::new();
                 capsules::process_console::COMMAND_HISTORY_LEN],
         );
 

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -325,8 +325,9 @@ pub unsafe fn main() {
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
+    const DEBUG_BUFFER_KB: usize = 1;
     components::debug_writer::DebugWriterComponent::new(uart_mux)
-        .finalize(components::debug_writer_component_static!());
+        .finalize(components::debug_writer_component_static!(DEBUG_BUFFER_KB));
 
     let lldb = components::lldb::LowLevelDebugComponent::new(
         board_kernel,

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -108,6 +108,7 @@ pub static mut STACK_MEMORY: [u8; 0x2000] = [0; 0x2000];
 struct Imix {
     pconsole: &'static capsules::process_console::ProcessConsole<
         'static,
+        { capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN },
         capsules::virtual_alarm::VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>,
         components::process_console::Capability,
     >,

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -114,6 +114,7 @@ struct LiteXArty {
     console: &'static capsules::console::Console<'static>,
     pconsole: &'static capsules::process_console::ProcessConsole<
         'static,
+        { capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN },
         VirtualMuxAlarm<
             'static,
             litex_vexriscv::timer::LiteXAlarm<

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -123,6 +123,7 @@ pub struct Platform {
     console: &'static capsules::console::Console<'static>,
     pconsole: &'static capsules::process_console::ProcessConsole<
         'static,
+        { capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN },
         capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf52::rtc::Rtc<'static>>,
         components::process_console::Capability,
     >,

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -82,6 +82,7 @@ pub struct Platform {
     button: &'static capsules::button::Button<'static, nrf52840::gpio::GPIOPin<'static>>,
     pconsole: &'static capsules::process_console::ProcessConsole<
         'static,
+        { capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN },
         VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
         components::process_console::Capability,
     >,

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -165,6 +165,7 @@ pub struct Platform {
     button: &'static capsules::button::Button<'static, nrf52840::gpio::GPIOPin<'static>>,
     pconsole: &'static capsules::process_console::ProcessConsole<
         'static,
+        { capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN },
         VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
         components::process_console::Capability,
     >,

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -72,7 +72,6 @@
 use capsules::i2c_master_slave_driver::I2CMasterSlaveDriver;
 use capsules::net::ieee802154::MacAddress;
 use capsules::net::ipv6::ip_utils::IPAddr;
-use capsules::process_console::Command;
 use capsules::virtual_aes_ccm::MuxAES128CCM;
 use capsules::virtual_alarm::VirtualMuxAlarm;
 use kernel::component::Component;

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -165,7 +165,7 @@ pub struct Platform {
     button: &'static capsules::button::Button<'static, nrf52840::gpio::GPIOPin<'static>>,
     pconsole: &'static capsules::process_console::ProcessConsole<
         'static,
-        { capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN },
+        20,
         VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
         components::process_console::Capability,
     >,
@@ -438,7 +438,8 @@ pub unsafe fn main() {
         process_printer,
     )
     .finalize(components::process_console_component_static!(
-        nrf52840::rtc::Rtc<'static>
+        nrf52840::rtc::Rtc<'static>,
+        20
     ));
 
     // Setup the console.

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -72,6 +72,7 @@
 use capsules::i2c_master_slave_driver::I2CMasterSlaveDriver;
 use capsules::net::ieee802154::MacAddress;
 use capsules::net::ipv6::ip_utils::IPAddr;
+use capsules::process_console::Command;
 use capsules::virtual_aes_ccm::MuxAES128CCM;
 use capsules::virtual_alarm::VirtualMuxAlarm;
 use kernel::component::Component;

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -165,7 +165,7 @@ pub struct Platform {
     button: &'static capsules::button::Button<'static, nrf52840::gpio::GPIOPin<'static>>,
     pconsole: &'static capsules::process_console::ProcessConsole<
         'static,
-        20,
+        { capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN },
         VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
         components::process_console::Capability,
     >,
@@ -438,8 +438,7 @@ pub unsafe fn main() {
         process_printer,
     )
     .finalize(components::process_console_component_static!(
-        nrf52840::rtc::Rtc<'static>,
-        20
+        nrf52840::rtc::Rtc<'static>
     ));
 
     // Setup the console.

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -141,6 +141,7 @@ pub struct Platform {
     button: &'static capsules::button::Button<'static, nrf52832::gpio::GPIOPin<'static>>,
     pconsole: &'static capsules::process_console::ProcessConsole<
         'static,
+        { capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN },
         VirtualMuxAlarm<'static, Rtc<'static>>,
         components::process_console::Capability,
     >,

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -102,6 +102,7 @@ pub struct Platform {
     button: &'static capsules::button::Button<'static, nrf52840::gpio::GPIOPin<'static>>,
     pconsole: &'static capsules::process_console::ProcessConsole<
         'static,
+        { capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN },
         VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
         components::process_console::Capability,
     >,

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -80,6 +80,7 @@ pub struct Platform {
     button: &'static capsules::button::Button<'static, nrf52840::gpio::GPIOPin<'static>>,
     pconsole: &'static capsules::process_console::ProcessConsole<
         'static,
+        { capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN },
         VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
         components::process_console::Capability,
     >,

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -162,9 +162,9 @@ impl Command {
         (&mut self.buf).copy_from_slice(buf);
     }
 
-    fn insert_byte(&mut self, byte: &u8) {
+    fn insert_byte(&mut self, byte: u8) {
         if self.len < COMMAND_BUF_LEN {
-            self.buf[self.len] = *byte;
+            self.buf[self.len] = byte;
             self.len = self.len + 1;
         }
     }
@@ -1050,10 +1050,13 @@ impl<'a, const COMMAND_HISTORY_LEN: usize, A: Alarm<'a>, C: ProcessManagementCap
                                 self.command_history.map(|cmd_arr| {
                                     if self.scrolled_in_history.get() {
                                         cmd_arr[0].clear();
+                                        for i in 0..(self.command_index.get() - 1) {
+                                            cmd_arr[0].insert_byte(command[i]);
+                                        }
                                         self.scrolled_in_history.set(false);
                                     }
 
-                                    cmd_arr[0].insert_byte(&read_buf[0]);
+                                    cmd_arr[0].insert_byte(read_buf[0]);
                                 });
                             }
                         }

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -988,6 +988,3 @@ impl<'a, A: Alarm<'a>, C: ProcessManagementCapability> uart::ReceiveClient
         let _ = self.uart.receive_buffer(read_buf, 1);
     }
 }
-
-/*
-*/

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -186,9 +186,11 @@ impl Default for Command {
 
 impl PartialEq<[u8; COMMAND_BUF_LEN]> for Command {
     fn eq(&self, other_buf: &[u8; COMMAND_BUF_LEN]) -> bool {
-        let mut bytes_iter = self.buf.iter().zip(other_buf.iter());
-        bytes_iter.all(|(a, b)| *a == *b && *a != TERMINATOR);
-        bytes_iter.next().eq(&Some((&TERMINATOR, &TERMINATOR)))
+        self.buf
+            .iter()
+            .zip(other_buf.iter())
+            .take_while(|(a, b)| **a != TERMINATOR || **b != TERMINATOR)
+            .all(|(a, b)| *a == *b)
     }
 }
 

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -87,14 +87,14 @@ impl Command {
     /// Fill the buffer with the provided data.
     /// If the provided data's length is smaller than the buffer length,
     /// the left over bytes are not modified due to '\0' termination.
-    pub fn fill(&mut self, buf: &[u8l COMMND_BUF_LEN], terminator_idx: usize) {
+    pub fn fill(&mut self, buf: &[u8; COMMAND_BUF_LEN], terminator_idx: usize) {
         self.len = if terminator_idx >= COMMAND_BUF_LEN {
             COMMAND_BUF_LEN
         } else {
             terminator_idx
         };
 
-        (&self.buf).copy_from_slice(&buf);
+        (&mut self.buf).copy_from_slice(buf);
     }
 
     pub fn is_buffer_empty(&mut self) -> bool {
@@ -536,7 +536,7 @@ impl<'a, const COMMAND_HISTORY_LEN: usize, A: Alarm<'a>, C: ProcessManagementCap
                                         cmd_arr[i] = cmd_arr[i - 1];
                                     }
 
-                                    cmd_arr[0].fill(command, terminator);
+                                    cmd_arr[0].fill(&command_array, terminator);
                                 }
                             });
                         }

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -87,7 +87,7 @@ impl Command {
     /// Fill the buffer with the provided data.
     /// If the provided data's length is smaller than the buffer length,
     /// the left over bytes are not modified due to '\0' termination.
-    pub fn fill(&mut self, buf: &[u8], terminator_idx: usize) {
+    pub fn fill(&mut self, buf: &[u8l COMMND_BUF_LEN], terminator_idx: usize) {
         self.len = if terminator_idx >= COMMAND_BUF_LEN {
             COMMAND_BUF_LEN
         } else {

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -189,7 +189,8 @@ impl PartialEq<[u8; COMMAND_BUF_LEN]> for Command {
         self.buf
             .iter()
             .zip(other_buf.iter())
-            .all(|(a, b)| *a != TERMINATOR && *b != TERMINATOR && a == b)
+            .take_while(|(a, b)| **a != TERMINATOR || **b != TERMINATOR)
+            .all(|(a, b)| a == b)
     }
 }
 

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -546,10 +546,7 @@ impl<'a, const COMMAND_HISTORY_LEN: usize, A: Alarm<'a>, C: ProcessManagementCap
                                     command_array.copy_from_slice(command);
 
                                     if cmd_arr[0] != command_array {
-                                        for i in (1..COMMAND_HISTORY_LEN).rev() {
-                                            cmd_arr[i] = cmd_arr[i - 1];
-                                        }
-
+                                        cmd_arr.rotate_right(1);
                                         cmd_arr[0].fill(&command_array, terminator);
                                     }
                                 });

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -950,6 +950,7 @@ impl<'a, const COMMAND_HISTORY_LEN: usize, A: Alarm<'a>, C: ProcessManagementCap
                             {
                                 // Reset the sequence, when \r\n is received
                                 self.previous_byte.set(0);
+                                self.command_history_index.insert(None);
                             } else {
                                 self.execute.set(true);
                                 let _ = self.write_bytes(&['\r' as u8, '\n' as u8]);

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -536,7 +536,7 @@ impl<'a, const COMMAND_HISTORY_LEN: usize, A: Alarm<'a>, C: ProcessManagementCap
                         let clean_str = s.trim();
 
                         // Try to add a new command to the history buffer
-                        if COMMAND_HISTORY_LEN > 0 {
+                        if clean_str.len() > 0 && COMMAND_HISTORY_LEN > 0 {
                             self.command_history.map(|cmd_arr| {
                                 if len == COMMAND_BUF_LEN {
                                     let mut command_array = [0; COMMAND_BUF_LEN];

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -164,8 +164,8 @@ impl Command {
     }
 
     fn insert_byte(&mut self, byte: u8) {
-        if self.len < COMMAND_BUF_LEN {
-            self.buf[self.len] = byte;
+        if let Some(buf_byte) = self.buf.get_mut(self.len) {
+            *buf_byte = byte;
             self.len = self.len + 1;
         }
     }

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -909,13 +909,17 @@ impl<'a, A: Alarm<'a>, C: ProcessManagementCapability> uart::ReceiveClient
                                             Some(i) => i + 1,
                                             None => 0,
                                         };
-                                        //check if there even is a command to move up to
-                                        self.command_history
-                                            .map(|cmd_arr| match cmd_arr[i][0] {
-                                                0 => None,
-                                                _ => Some(i),
-                                            })
-                                            .unwrap()
+                                        if i >= COMMAND_HISTORY_LEN {
+                                            None
+                                        } else {
+                                            //check if there even is a command to move up to
+                                            self.command_history
+                                                .map(|cmd_arr| match cmd_arr[i][0] {
+                                                    0 => None,
+                                                    _ => Some(i),
+                                                })
+                                                .unwrap()
+                                        }
                                     }
                                     //down arrow case
                                     b'B' => {

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -171,9 +171,9 @@ impl Command {
     }
 
     fn delete_last_byte(&mut self) {
-        if self.len > 0 {
-            self.len -= 1;
-            self.buf[self.len] = EOL;
+        if let Some(buf_byte) = self.buf.get_mut(self.len - 1) {
+            *buf_byte = EOL;
+            self.len = self.len - 1;
         }
     }
 

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -964,7 +964,9 @@ impl<'a, const COMMAND_HISTORY_LEN: usize, A: Alarm<'a>, C: ProcessManagementCap
                                 command[index - 1] = EOL;
                                 self.command_index.set(index - 1);
                             }
-                        } else if read_buf[0] == ESC || self.control_seq_in_progress.get() {
+                        } else if (COMMAND_HISTORY_LEN > 0)
+                            && (read_buf[0] == ESC || self.control_seq_in_progress.get())
+                        {
                             // Catch the Up and Down arrow keys
                             if read_buf[0] == ESC {
                                 // Signal that a control sequence has started and capture it

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -34,7 +34,7 @@ pub const READ_BUF_LEN: usize = 4;
 /// characters, limiting arguments to 25 bytes or so seems fine for now.
 pub const COMMAND_BUF_LEN: usize = 32;
 
-pub const DEFAULT_COMMAND_HISTORY_LEN: usize = 11;
+pub const DEFAULT_COMMAND_HISTORY_LEN: usize = 10;
 
 /// List of valid commands for printing help. Consolidated as these are
 /// displayed in a few different cases.
@@ -162,8 +162,10 @@ impl Command {
     }
 
     fn insert_byte(&mut self, byte: &u8) {
-        self.buf[self.len] = *byte;
-        self.len = self.len + 1;
+        if self.len < COMMAND_BUF_LEN {
+            self.buf[self.len] = *byte;
+            self.len = self.len + 1;
+        }
     }
 
     fn clear(&mut self) {
@@ -1035,9 +1037,12 @@ impl<'a, const COMMAND_HISTORY_LEN: usize, A: Alarm<'a>, C: ProcessManagementCap
                             command[index] = read_buf[0];
                             self.command_index.set(index + 1);
                             command[index + 1] = 0;
-                            self.command_history.map(|cmd_arr| {
-                                (&mut cmd_arr[0]).insert_byte(&read_buf[0]);
-                            });
+
+                            if COMMAND_HISTORY_LEN > 1 {
+                                self.command_history.map(|cmd_arr| {
+                                    (&mut cmd_arr[0]).insert_byte(&read_buf[0]);
+                                });
+                            }
                         }
                     });
                 }

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -526,19 +526,21 @@ impl<'a, const COMMAND_HISTORY_LEN: usize, A: Alarm<'a>, C: ProcessManagementCap
                         let clean_str = s.trim();
 
                         // Try to add a new command to the history buffer
-                        if clean_str.len() > 0 && COMMAND_HISTORY_LEN > 0 {
-                            self.command_history.map(|cmd_arr| {
-                                let mut command_array = [0; COMMAND_BUF_LEN];
-                                command_array.copy_from_slice(command);
+                        if COMMAND_HISTORY_LEN > 0 {
+                            if clean_str.len() > 0 {
+                                self.command_history.map(|cmd_arr| {
+                                    let mut command_array = [0; COMMAND_BUF_LEN];
+                                    command_array.copy_from_slice(command);
 
-                                if !cmd_arr[0].same_bytes(&command_array) {
-                                    for i in (1..COMMAND_HISTORY_LEN).rev() {
-                                        cmd_arr[i] = cmd_arr[i - 1];
+                                    if !cmd_arr[0].same_bytes(&command_array) {
+                                        for i in (1..COMMAND_HISTORY_LEN).rev() {
+                                            cmd_arr[i] = cmd_arr[i - 1];
+                                        }
+
+                                        cmd_arr[0].fill(&command_array, terminator);
                                     }
-
-                                    cmd_arr[0].fill(&command_array, terminator);
-                                }
-                            });
+                                });
+                            }
                         }
 
                         if clean_str.starts_with("help") {

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -533,23 +533,25 @@ impl<'a, A: Alarm<'a>, C: ProcessManagementCapability> ProcessConsole<'a, A, C> 
                         let clean_str = s.trim();
 
                         // Try to add a new command to the history buffer
-                        self.command_history.map(|cmd_arr| {
-                            if !cmd_arr[0].same_bytes(command, terminator + 1) {
-                                for i in (1..DEFAULT_COMMAND_HISTORY_LEN).rev() {
-                                    cmd_arr[i] = cmd_arr[i - 1];
-                                }
+                        if DEFAULT_COMMAND_HISTORY_LEN > 0 {
+                            self.command_history.map(|cmd_arr| {
+                                if !cmd_arr[0].same_bytes(command, terminator + 1) {
+                                    for i in (1..DEFAULT_COMMAND_HISTORY_LEN).rev() {
+                                        cmd_arr[i] = cmd_arr[i - 1];
+                                    }
 
-                                match cmd_arr[0].fill(command, terminator + 1) {
-                                    Err(_) => {
-                                        let _ =
-                                            self.write_bytes(b"Error: input command too long.\r\n");
-                                    }
-                                    _ => {
-                                        // Ignore the Ok message
+                                    match cmd_arr[0].fill(command, terminator + 1) {
+                                        Err(_) => {
+                                            let _ = self
+                                                .write_bytes(b"Error: input command too long.\r\n");
+                                        }
+                                        _ => {
+                                            // Ignore the Ok message
+                                        }
                                     }
                                 }
-                            }
-                        });
+                            });
+                        }
 
                         if clean_str.starts_with("help") {
                             let _ = self.write_bytes(b"Welcome to the process console.\r\n");

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -94,7 +94,7 @@ impl Command {
             terminator_idx
         };
 
-        self.buf[..self.len].copy_from_slice(&buf[..self.len]);
+        (&self.buf).copy_from_slice(&buf);
     }
 
     pub fn is_buffer_empty(&mut self) -> bool {

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -186,11 +186,9 @@ impl Default for Command {
 
 impl PartialEq<[u8; COMMAND_BUF_LEN]> for Command {
     fn eq(&self, other_buf: &[u8; COMMAND_BUF_LEN]) -> bool {
-        self.buf
-            .iter()
-            .zip(other_buf.iter())
-            .take_while(|(a, b)| **a != TERMINATOR || **b != TERMINATOR)
-            .all(|(a, b)| a == b)
+        let mut bytes_iter = self.buf.iter().zip(other_buf.iter());
+        bytes_iter.all(|(a, b)| *a == *b && *a != TERMINATOR);
+        bytes_iter.next().eq(&Some((&TERMINATOR, &TERMINATOR)))
     }
 }
 

--- a/doc/Process_Console.md
+++ b/doc/Process_Console.md
@@ -604,11 +604,3 @@ tock$
       0x00040800 ┴─────────────────────────────────────────── H
 
 ```
-<<<<<<< HEAD
-=======
-
- ### `up and down arrows`
- - You can use the up and down arrows to scroll through the command history and to view the previous commands you have run.
- - If you inserted more commands than the command history can hold, the oldest commands will be overwritten.
- - You can view the commands in bidirectional order, `up arrow` for oldest commands and `down arrow` for newest.
->>>>>>> Copied the ProcessConsole from the upstream adnd added new documentation for the ProcessConsole using custom COMMAND_HISTORY_LEN

--- a/doc/Process_Console.md
+++ b/doc/Process_Console.md
@@ -43,10 +43,10 @@ Setup
     ));
  let _ = _process_console.start();
  ```
-> Note: Using the process console might require allocating more stack to the kernel. This is done by modifying the `STACK_MEMORY` variable from the board's `main.rs`.
-
- Using Process Console
- --------------------
+<<<<<<< HEAD
+=======
+ Here is how to add a custom size for the command `history` used by the ProcessConsole structure to keep track of the typed commands:
+ ```rust
 
  With this capsule properly added to a board's `main.rs` and the Tock kernel
  loaded to the board, make sure there is a serial connection to the board.
@@ -85,6 +85,10 @@ tock$
   - [`panic`](#panic) - causes the kernel to run the panic handler
   - [`kernel`](#kernel) - prints the kernel memory map
   - [`process n`](#process) - prints the memory map of process with name n
+<<<<<<< HEAD
+=======
+  - [`up and down arrows`](#up-and-down-arrows) - scroll through the command history
+>>>>>>> Copied the ProcessConsole from the upstream adnd added new documentation for the ProcessConsole using custom COMMAND_HISTORY_LEN
 
  For the examples below we will have 2 processes on the board: `blink` (which will blink all the LEDs that are 
  connected to the kernel), and `c_hello` (which prints 'Hello World' when the console is started). Also, a micro:bit v2 board was used as support for the commands, so the results may vary on other devices.
@@ -600,3 +604,11 @@ tock$
       0x00040800 ┴─────────────────────────────────────────── H
 
 ```
+<<<<<<< HEAD
+=======
+
+ ### `up and down arrows`
+ - You can use the up and down arrows to scroll through the command history and to view the previous commands you have run.
+ - If you inserted more commands than the command history can hold, the oldest commands will be overwritten.
+ - You can view the commands in bidirectional order, `up arrow` for oldest commands and `down arrow` for newest.
+>>>>>>> Copied the ProcessConsole from the upstream adnd added new documentation for the ProcessConsole using custom COMMAND_HISTORY_LEN

--- a/doc/Process_Console.md
+++ b/doc/Process_Console.md
@@ -609,6 +609,8 @@ tock$
  - If you inserted more commands than the command history can hold, oldest commands will be overwritten.
  - You can view the commands in bidirectional order, `up arrow` for oldest commands and `down arrow` for newest.
  - If the user custom size for the history is set to `0`, the history will be disabled and the rust compiler will be able to optimize the binary file by removing dead code.
+ - If you are typing a command and accidentally press the `up arrow` key, you can press `down arrow` in order to retrieve the command you were typing.
+ - If you scroll through the history and you want to edit a command and accidentally press the `up` or `down` arrow key, scroll to the bottom of the history and you will get back to the command you were typing.
 
   Here is how to add a custom size for the command `history` used by the ProcessConsole structure to keep track of the typed commands, in the `main.rs` of boards:
  ```rust
@@ -621,7 +623,7 @@ tock$
     
     pconsole: &'static capsules::process_console::ProcessConsole<
         'static,
-        { CUSTOM_HISTORY_LEN },
+        { COMMAND_HISTORY_LEN },
         // or { capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN }
         // for the deafult behaviour
         VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
@@ -646,4 +648,4 @@ tock$
 
   /// ...
  ```
-> Note: In order to disable any functionality for the command history set the `CUSTOM_HISTORY_LEN` as `0`.
+> Note: In order to disable any functionality for the command history set the `COMMAND_HISTORY_LEN` as `0`, also the history will be disabled for a size of `1`, because the first position from the command history is reserved for accidents by pressing `up` or `down` arrow key.

--- a/doc/Process_Console.md
+++ b/doc/Process_Console.md
@@ -648,4 +648,4 @@ tock$
 
   /// ...
  ```
-> Note: In order to disable any functionality for the command history set the `COMMAND_HISTORY_LEN` as `0`, also the history will be disabled for a size of `1`, because the first position from the command history is reserved for accidents by pressing `up` or `down` arrow key.
+> Note: In order to disable any functionality for the command history set the `COMMAND_HISTORY_LEN` to `0` or `1` (the history will be disabled for a size of `1`, because the first position from the command history is reserved for accidents by pressing `up` or `down` arrow key.

--- a/doc/Process_Console.md
+++ b/doc/Process_Console.md
@@ -646,4 +646,4 @@ tock$
 
   /// ...
  ```
-> Note: In order to disable any functionality for the command history set the `CUSTOM_HISTORY_LEN` as `0`. 
+> Note: In order to disable any functionality for the command history set the `CUSTOM_HISTORY_LEN` as `0`.

--- a/doc/Process_Console.md
+++ b/doc/Process_Console.md
@@ -614,7 +614,7 @@ tock$
 
   Here is how to add a custom size for the command `history` used by the ProcessConsole structure to keep track of the typed commands, in the `main.rs` of boards:
  ```rust
- const CUSTOM_HISTORY_LEN : usize = 30;
+ const COMMAND_HISTORY_LEN : usize = 30;
 
  /// ...
  
@@ -623,7 +623,7 @@ tock$
     
     pconsole: &'static capsules::process_console::ProcessConsole<
         'static,
-        { COMMAND_HISTORY_LEN },
+        COMMAND_HISTORY_LEN,
         // or { capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN }
         // for the deafult behaviour
         VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
@@ -643,7 +643,7 @@ tock$
       )
       .finalize(components::process_console_component_static!(
           nrf52833::rtc::Rtc,
-          CUSTOM_HISTORY_LEN // or nothing for the default behaviour
+          COMMAND_HISTORY_LEN // or nothing for the default behaviour
       ));
 
   /// ...

--- a/doc/reference/trd-legal.md
+++ b/doc/reference/trd-legal.md
@@ -24,8 +24,8 @@ Explicitly not discussed in this TRD are issues of trademark, the Tock brand,
 logos, or other non-code assets and artifacts.
 
 
-1. Introduction
-===============
+1 Introduction
+==============
 
 Tock’s goal is to provide a safe, secure, and efficient operating system for
 microcontroller-class devices. The Tock project further believes it is
@@ -39,8 +39,8 @@ The intent of these policies is to best satisfy the needs of all stakeholders
 in the Tock ecosystem.
 
 
-2. Licensing
-============
+2 Licensing
+===========
 
 All software artifacts under the umbrella of the Tock project are
 dual-licensed as Apache License, Version 2.0 (LICENSE-APACHE or
@@ -50,8 +50,8 @@ http://opensource.org/licenses/MIT).
 All contributions to Tock projects MUST be licensed under these terms.
 
 
-3. Copyright
-============
+3 Copyright
+===========
 
 Entities contributing resources to open-source projects often require
 attribution to recognize their efforts. Copyright notices are a common means to
@@ -69,8 +69,8 @@ the original copyright holder.
 For full authorship information, see the version control history.
 
 
-4. Implementation
-=================
+4 Implementation
+================
 
 All code artifacts in Tock projects MUST include a license notice.
 
@@ -173,7 +173,7 @@ this policy. Such situations MUST include public explanation and public
 record of non-anonymized vote results. This is not expected to ever occur.
 
 
-6 Author’s Address
+5 Author’s Address
 ==================
 
     Pat Pannuto

--- a/doc/reference/trd-legal.md
+++ b/doc/reference/trd-legal.md
@@ -3,7 +3,7 @@ Licensing and Copyrights
 
 **TRD:** <br/>
 **Working Group:** Core<br/>
-**Type:** Documentary<br/>
+**Type:** Best Current Practice<br/>
 **Status:** Draft <br/>
 **Author:** Pat Pannuto<br/>
 **Draft-Created:** 2022/11/05 <br/>
@@ -42,11 +42,6 @@ in the Tock ecosystem.
 2. Licensing
 ============
 
-Tock’s primary licensing goal is to ensure ease of use for Tock project elements.
-For this reason, Tock offers its resources under the minimally encumbered MIT
-license and under the Apache2 license for those entities concerned about possible
-litigation issues.
-
 All software artifacts under the umbrella of the Tock project are
 dual-licensed as Apache License, Version 2.0 (LICENSE-APACHE or
 http://www.apache.org/licenses/LICENSE-2.0) or MIT license (LICENSE-MIT or
@@ -58,17 +53,18 @@ All contributions to Tock projects MUST be licensed under these terms.
 3. Copyright
 ============
 
-Entities contributing resources to open-source projects often require attribution
-to recognize their efforts. Copyright is a common means to provide this. For
-downstream users, the license terms of Tock ensures unencumbered use.
+Entities contributing resources to open-source projects often require
+attribution to recognize their efforts. Copyright notices are a common means to
+provide this. For downstream users, the license terms of Tock ensures
+unencumbered use.
 
 Copyrights in Tock projects are retained by their contributors. No
 copyright assignment is required to contribute to Tock projects.
 
 Artifacts in the Tock project MAY include explicit copyright notices.
 Substantial updates to an artifact MAY add additional copyright notices
-to an artifact. Copyright notices MUST NOT be removed by any party except
-the original copyright holder, and removal is done solely at their discretion.
+to an artifact. Copyright notices SHOULD NOT be removed by any party except
+the original copyright holder.
 
 For full authorship information, see the version control history.
 
@@ -78,8 +74,8 @@ For full authorship information, see the version control history.
 
 All code artifacts in Tock projects MUST include a license notice.
 
-Code artifacts MAY include copyright notice(s). Copyright notices MUST
-include a year. Newer copyright notices MUST be placed after existing
+Code artifacts MAY include copyright notice(s). Copyright notices SHOULD
+include a year. Newer copyright notices SHOULD be placed after existing
 copyright notices. If non-trivial updates are performed by an original
 copyright author, they MAY amend the year(s) indicated on their existing
 copyright statement or MAY add an additional copyright line, at their
@@ -89,49 +85,46 @@ discretion.
 4.1 Format
 ----------
 
-License and copyright information MUST appear near the top of a file.
-Generally, license and copyright information SHOULD be the first lines
-in a file, however exceptions may be made where technically necessary
-(e.g. to accommodate the shebang in a shell script).
+License and copyright information SHOULD appear near the top of a file.
+Generally, license and copyright information SHOULD be the first lines in a file
+unless necessary for technical (e.g. to accommodate the shebang in a shell
+script) or other reasons (e.g. importing a file with an existing copyright
+notice in a different location).
 
-License and copyright information MUST have exactly one (1) blank line
+License and copyright information SHOULD have exactly one (1) blank line
 separating it from any other content in the file.
 
-License information MUST come before copyright information.
-There MUST NOT be any whitespace between lines in the license/copyright block.
-
-Text described in this section MAY be pre-fixed or post-fixed with
+Text described in this section SHOULD be pre-fixed or post-fixed with
 technically necessary characters (i.e. to mark as a comment in source
 code) as appropriate.
 
-The first line of license text MUST appear exactly as-follows:
+The first line of license text SHOULD appear as-follows:
 
 > Licensed under the Apache License, Version 2.0 or the MIT License.
 
-The second line of license MUST adhere to the [SPDX](https//spdx.dev)
+The second line of license SHOULD adhere to the [SPDX](https//spdx.dev)
 specification for license description. As of this writing, it SHOULD
 appear as-follows:
 
 > SPDX-License-Identifier: Apache-2.0 OR MIT
 
-The [current (v2.3) normative rules](https://spdx.github.io/spdx-spec/v2.3/SPDX-license-expressions/)
-permit case-insensitive matches of the license identifier but require
-case-sensitive matching of the disjunction operator. To simplify
-enforcement of licensing and documentation rules, Tock dictates that
-license information MUST preserve case as-shown in the SPDX license
-list (i.e. as-presented above).
+The [current (v2.3) normative
+rules](https://spdx.github.io/spdx-spec/v2.3/SPDX-license-expressions/) permit
+case-insensitive matches of the license identifier but require case-sensitive
+matching of the disjunction operator. To simplify enforcement of licensing and
+documentation rules, license information SHOULD preserve case as-shown in the
+SPDX license list (i.e. as-presented above).
 
-Copyright lines MUST follow this pattern:
+Copyright lines SHOULD follow this pattern:
 
 > Copyright {entity} {year}([,year],[-year]).
 
-The `{entity}` field is REQUIRED and should reflect the entity wishing
-to claim copyright. The `{year}` field is REQUIRED and should reflect
-when the copyright is first established. Substantial updates in the
-future MAY indicate renewed copyright, via additional comma-separated
-years or via range syntax, at the copyright holder’s discretion. The
-initial year SHALL NOT be removed unless it is the express intent of
-the copyright holder to relinquish the initial copyright.
+The `{entity}` field should reflect the entity wishing to claim copyright. The
+`{year}` field SHOULD reflect when the copyright is first established.
+Substantial updates in the future MAY indicate renewed copyright, via additional
+comma-separated years or via range syntax, at the copyright holder’s discretion.
+The initial year SHALL NOT be removed unless it is the express intent of the
+copyright holder to relinquish the initial copyright.
 
 
 ### 4.1.1 Examples
@@ -144,6 +137,8 @@ The common-case format is the top of a file with only license information:
 
 //! Module-level documentation...
 ```
+
+It need not include a copyright line.
 
 A file with a long history and multiple copyrights may look as follows:
 
@@ -168,7 +163,7 @@ Many additional examples are available throughout the Tock repositories.
 ---------------
 
 To ensure coverage and compliance with these policies, the Core Team
-SHALL author and maintain tooling which enforces the presence and correct
+SHALL author and maintain tooling which checks the presence and expected
 format of license and copyright information. This SHOULD be automated and
 integrated with continuous integration systems. Contributions which do
 not satisfy these license and copyright rules MUST NOT be accepted.

--- a/doc/reference/trd-legal.md
+++ b/doc/reference/trd-legal.md
@@ -1,0 +1,188 @@
+Licensing and Copyrights
+========================================
+
+**TRD:** <br/>
+**Working Group:** Core<br/>
+**Type:** Documentary<br/>
+**Status:** Draft <br/>
+**Author:** Pat Pannuto<br/>
+**Draft-Created:** 2022/11/05 <br/>
+**Draft-Modified:** 2022/11/05 <br/>
+**Draft-Version:** 1 <br/>
+**Draft-Discuss:** tock-dev@googlegroups.com<br/>
+
+Abstract
+--------
+
+This document describes Tock’s policy on licensing and copyright. It explains
+the rationale behind the license selection (dual-license, MIT or Apache2) and
+copyright policy (optional, and authors may retain copyright if desired). It
+further outlines how licensing and copyright shall be handled throughout
+projects under the Tock umbrella.
+
+Explicitly not discussed in this TRD are issues of trademark, the Tock brand,
+logos, or other non-code assets and artifacts.
+
+
+1. Introduction
+===============
+
+Tock’s goal is to provide a safe, secure, and efficient operating system for
+microcontroller-class devices. The Tock project further believes it is
+important to enable and support widespread adoption of safe, secure, and
+efficient software. Tock also seeks to be an open and inclusive project, and
+Tock welcomes contributions from any individuals or entities wishing to
+improve the safety, security, reliability, efficiency, or usability of Tock
+and the Tock ecosystem.
+
+The intent of these policies is to best satisfy the needs of all stakeholders
+in the Tock ecosystem.
+
+
+2. Licensing
+============
+
+Tock’s primary licensing goal is to ensure ease of use for Tock project elements.
+For this reason, Tock offers its resources under the minimally encumbered MIT
+license and under the Apache2 license for those entities concerned about possible
+litigation issues.
+
+All software artifacts under the umbrella of the Tock project are
+dual-licensed as Apache License, Version 2.0 (LICENSE-APACHE or
+http://www.apache.org/licenses/LICENSE-2.0) or MIT license (LICENSE-MIT or
+http://opensource.org/licenses/MIT).
+
+All contributions to Tock projects MUST be licensed under these terms.
+
+
+3. Copyright
+============
+
+Entities contributing resources to open-source projects often require attribution
+to recognize their efforts. Copyright is a common means to provide this. For
+downstream users, the license terms of Tock ensures unencumbered use.
+
+Copyrights in Tock projects are retained by their contributors. No
+copyright assignment is required to contribute to Tock projects.
+
+Artifacts in the Tock project MAY include explicit copyright notices.
+Substantial updates to an artifact MAY add additional copyright notices
+to an artifact. Copyright notices MUST NOT be removed by any party except
+the original copyright holder, and removal is done solely at their discretion.
+
+For full authorship information, see the version control history.
+
+
+4. Implementation
+=================
+
+All code artifacts in Tock projects MUST include a license notice.
+
+Code artifacts MAY include copyright notice(s). Copyright notices MUST
+include a year. Newer copyright notices MUST be placed after existing
+copyright notices. If non-trivial updates are performed by an original
+copyright author, they MAY amend the year(s) indicated on their existing
+copyright statement or MAY add an additional copyright line, at their
+discretion.
+
+
+4.1 Format
+----------
+
+License and copyright information MUST appear near the top of a file.
+Generally, license and copyright information SHOULD be the first lines
+in a file, however exceptions may be made where technically necessary
+(e.g. to accommodate the shebang in a shell script).
+
+License and copyright information MUST have exactly one (1) blank line
+separating it from any other content in the file.
+
+License information MUST come before copyright information.
+There MUST NOT be any whitespace between lines in the license/copyright block.
+
+Text described in this section MAY be pre-fixed or post-fixed with
+technically necessary characters (i.e. to mark as a comment in source
+code) as appropriate.
+
+The first line of license text MUST appear exactly as-follows:
+
+> Licensed under the Apache License, Version 2.0 or the MIT License.
+
+The second line of license MUST adhere to the [SPDX](https//spdx.dev)
+specification for license description. As of this writing, it SHOULD
+appear as-follows:
+
+> SPDX-License-Identifier: Apache-2.0 OR MIT
+
+The [current (v2.3) normative rules](https://spdx.github.io/spdx-spec/v2.3/SPDX-license-expressions/)
+permit case-insensitive matches of the license identifier but require
+case-sensitive matching of the disjunction operator. To simplify
+enforcement of licensing and documentation rules, Tock dictates that
+license information MUST preserve case as-shown in the SPDX license
+list (i.e. as-presented above).
+
+Copyright lines MUST follow this pattern:
+
+> Copyright {entity} {year}([,year],[-year]).
+
+The `{entity}` field is REQUIRED and should reflect the entity wishing
+to claim copyright. The `{year}` field is REQUIRED and should reflect
+when the copyright is first established. Substantial updates in the
+future MAY indicate renewed copyright, via additional comma-separated
+years or via range syntax, at the copyright holder’s discretion. The
+initial year SHALL NOT be removed unless it is the express intent of
+the copyright holder to relinquish the initial copyright.
+
+
+### 4.1.1 Examples
+
+The common-case format is the top of a file with only license information:
+
+```rust
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Module-level documentation...
+```
+
+A file with a long history and multiple copyrights may look as follows:
+
+```bash
+#!/usr/bin/env bash
+
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Pat Pannuto 2014,2016-2018,2021.
+# Copyright Tock Project Developers 2015.
+# Copyright Amit Levy 2016-2019.
+# Copyright Bradford James Campbell 2022.
+
+set -e
+...
+```
+
+Many additional examples are available throughout the Tock repositories.
+
+
+4.2 Enforcement
+---------------
+
+To ensure coverage and compliance with these policies, the Core Team
+SHALL author and maintain tooling which enforces the presence and correct
+format of license and copyright information. This SHOULD be automated and
+integrated with continuous integration systems. Contributions which do
+not satisfy these license and copyright rules MUST NOT be accepted.
+
+In exceptional situations, consensus from the Core Team MAY circumvent
+this policy. Such situations MUST include public explanation and public
+record of non-anonymized vote results. This is not expected to ever occur.
+
+
+6 Author’s Address
+==================
+
+    Pat Pannuto
+    3202 EBU3, Mail Code #0404
+    9500 Gilman Dr
+    La Jolla, CA 92093, USA
+    ppannuto@ucsd.edu

--- a/doc/reference/trd-legal.md
+++ b/doc/reference/trd-legal.md
@@ -87,7 +87,7 @@ discretion.
 4.1 Format
 ----------
 
-License and copyright information SHOULD have exactly one (1) blank line
+License and copyright information SHOULD have at least one (1) blank line
 separating it from any other content in the file.
 
 Text described in this section SHOULD be pre-fixed or post-fixed with
@@ -131,12 +131,23 @@ The common-case format is:
 // Licensed under the Apache License, Version 2.0 or the MIT License.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors <YYYY>.
-// Copyright <you/your company> <YYYY>.
 
 //! Module-level documentation...
 ```
 
 placed at the top of the file.
+
+If you wish to specifically call out the contribution by you or your company,
+you may do so by adding another copyright line:
+
+```rust
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors <YYYY>.
+// Copyright <you/your company> <YYYY>.
+
+//! Module-level documentation...
+```
 
 A file with a long history and multiple copyrights may look as follows:
 

--- a/doc/reference/trd-legal.md
+++ b/doc/reference/trd-legal.md
@@ -47,7 +47,8 @@ dual-licensed as Apache License, Version 2.0 (LICENSE-APACHE or
 http://www.apache.org/licenses/LICENSE-2.0) or MIT license (LICENSE-MIT or
 http://opensource.org/licenses/MIT).
 
-All contributions to Tock projects MUST be licensed under these terms.
+All contributions to the Tock kernel (the code hosted at
+https://github.com/tock/tock) MUST be licensed under these terms.
 
 
 3 Copyright
@@ -62,9 +63,9 @@ Copyrights in Tock projects are retained by their contributors. No
 copyright assignment is required to contribute to Tock projects.
 
 Artifacts in the Tock project MAY include explicit copyright notices.
-Substantial updates to an artifact MAY add additional copyright notices
-to an artifact. Copyright notices SHOULD NOT be removed by any party except
-the original copyright holder.
+Substantial updates to an artifact MAY add additional copyright notices to an
+artifact. In general, modifications to a file are expected to retain existing
+copyright notices.
 
 For full authorship information, see the version control history.
 
@@ -72,7 +73,7 @@ For full authorship information, see the version control history.
 4 Implementation
 ================
 
-All code artifacts in Tock projects MUST include a license notice.
+All textual files that allow comments MUST include a license notice.
 
 Code artifacts MAY include copyright notice(s). Copyright notices SHOULD
 include a year. Newer copyright notices SHOULD be placed after existing
@@ -84,12 +85,6 @@ discretion.
 
 4.1 Format
 ----------
-
-License and copyright information SHOULD appear near the top of a file.
-Generally, license and copyright information SHOULD be the first lines in a file
-unless necessary for technical (e.g. to accommodate the shebang in a shell
-script) or other reasons (e.g. importing a file with an existing copyright
-notice in a different location).
 
 License and copyright information SHOULD have exactly one (1) blank line
 separating it from any other content in the file.

--- a/doc/reference/trd-legal.md
+++ b/doc/reference/trd-legal.md
@@ -73,13 +73,13 @@ For full authorship information, see the version control history.
 4 Implementation
 ================
 
-All textual files that allow comments MUST include a license notice.
+All textual files that allow comments MUST include a license notice and
+copyright notice(s).
 
-Code artifacts MAY include copyright notice(s). Copyright notices SHOULD
-include a year. Newer copyright notices SHOULD be placed after existing
-copyright notices. If non-trivial updates are performed by an original
-copyright author, they MAY amend the year(s) indicated on their existing
-copyright statement or MAY add an additional copyright line, at their
+Copyright notices SHOULD include a year. Newer copyright notices SHOULD be
+placed after existing copyright notices. If non-trivial updates are performed by
+an original copyright author, they MAY amend the year(s) indicated on their
+existing copyright statement or MAY add an additional copyright line, at their
 discretion.
 
 

--- a/doc/reference/trd-legal.md
+++ b/doc/reference/trd-legal.md
@@ -73,8 +73,9 @@ For full authorship information, see the version control history.
 4 Implementation
 ================
 
-All textual files that allow comments MUST include a license notice and
-copyright notice(s).
+Where possible, all textual files that allow comments MUST include a license
+notice and copyright notice(s). Files that are not authored by Tock contributors
+(such as files copied from other projects) are exempt from this policy.
 
 Copyright notices SHOULD include a year. Newer copyright notices SHOULD be
 placed after existing copyright notices. If non-trivial updates are performed by
@@ -124,16 +125,18 @@ copyright holder to relinquish the initial copyright.
 
 ### 4.1.1 Examples
 
-The common-case format is the top of a file with only license information:
+The common-case format is:
 
 ```rust
 // Licensed under the Apache License, Version 2.0 or the MIT License.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors <YYYY>.
+// Copyright <you/your company> <YYYY>.
 
 //! Module-level documentation...
 ```
 
-It need not include a copyright line.
+placed at the top of the file.
 
 A file with a long history and multiple copyrights may look as follows:
 
@@ -142,8 +145,8 @@ A file with a long history and multiple copyrights may look as follows:
 
 # Licensed under the Apache License, Version 2.0 or the MIT License.
 # SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2014.
 # Copyright Pat Pannuto 2014,2016-2018,2021.
-# Copyright Tock Project Developers 2015.
 # Copyright Amit Levy 2016-2019.
 # Copyright Bradford James Campbell 2022.
 

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "alert_codes",
     "board-runner",
+    "license-checker",
     "litex-ci-runner",
     "qemu-runner",
     "sha256sum",

--- a/tools/license-checker/Cargo.toml
+++ b/tools/license-checker/Cargo.toml
@@ -1,0 +1,19 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2022
+# Copyright Google LLC 2022
+
+[package]
+name = "license-checker"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+
+[dependencies]
+ignore = "0.4"
+thiserror = "1.0.37"
+
+[dependencies.syntect]
+default-features = false
+features = ["default-syntaxes", "regex-onig"]
+version = "5.0.0"

--- a/tools/license-checker/Cargo.toml
+++ b/tools/license-checker/Cargo.toml
@@ -10,6 +10,7 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
+clap = { features = ["derive"], version = "4.0.29" }
 ignore = "0.4"
 thiserror = "1.0.37"
 

--- a/tools/license-checker/src/main.rs
+++ b/tools/license-checker/src/main.rs
@@ -37,6 +37,13 @@ fn is_copyright(comment: &str) -> bool {
     comment.starts_with("Copyright ")
 }
 
+#[derive(clap::Parser)]
+struct Args {
+    /// Enable verbose debugging output
+    #[arg(long, short)]
+    verbose: bool,
+}
+
 #[derive(Debug, thiserror::Error, PartialEq)]
 enum LicenseError {
     #[error("license header missing")]
@@ -147,6 +154,8 @@ fn check_file(cache: &Cache, path: &Path) -> Vec<ErrorInfo> {
 }
 
 fn main() {
+    use clap::Parser as _;
+    let args = Args::parse();
     let cache = &Cache::default();
     let fs_walk = WalkBuilder::new("./")
         .add_custom_ignore_filename(".lcignore")
@@ -162,6 +171,9 @@ fn main() {
         let file_type = dir_entry.file_type().expect("File type read failed");
         if !file_type.is_file() {
             continue;
+        }
+        if args.verbose {
+            println!("Checking {}", dir_entry.path().display());
         }
         for error_info in check_file(cache, dir_entry.path()) {
             failed = true;

--- a/tools/license-checker/src/main.rs
+++ b/tools/license-checker/src/main.rs
@@ -1,0 +1,258 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022
+// Copyright Google LLC 2022
+
+//! License-header checking tool for the Tock project.
+//!
+//! # Description
+//! This tool recursively traverses through the current working directory,
+//! verifying that every source code file inside has a Tock project license
+//! header.
+//!
+//! # Ignore files
+//! This tool respects gitignore files with the following names (ordered from
+//! highest-precedence to lowest-precedence):
+//! 1. .lcignore
+//! 2. .ignore
+//! 3. .gitignore
+
+use ignore::WalkBuilder;
+use std::path::{Path, PathBuf};
+use std::process::exit;
+
+mod parser;
+use parser::{Cache, LineContents, ParseError, Parser};
+
+const LICENSED_LINE: &str = "Licensed under the Apache License, Version 2.0 or the MIT License.";
+const SPDX_LINE: &str = "SPDX-License-Identifier: Apache-2.0 OR MIT";
+
+fn is_first(comment: &str) -> bool {
+    comment.starts_with("Licensed under ")
+}
+fn is_spdx(comment: &str) -> bool {
+    comment.starts_with("SPDX-License-Identifier:")
+}
+fn is_copyright(comment: &str) -> bool {
+    comment.starts_with("Copyright ")
+}
+
+#[derive(Debug, thiserror::Error, PartialEq)]
+enum LicenseError {
+    #[error("license header missing")]
+    Missing,
+
+    #[error("missing blank line after header")]
+    MissingBlank,
+
+    #[error("missing copyright line")]
+    MissingCopyright,
+
+    #[error("missing SPDX line")]
+    MissingSpdx,
+
+    #[error("incorrect first line")]
+    WrongFirst,
+
+    #[error("wrong SPDX line")]
+    WrongSpdx,
+}
+
+#[derive(Debug, PartialEq)]
+struct ErrorInfo {
+    file: PathBuf,
+    line_num: u64,
+    error: LicenseError,
+}
+
+#[derive(PartialEq)]
+enum State {
+    /// We need a blank line before the header can start. This state is entered
+    /// if there is a non-blank, non-license-header line before the license
+    /// header.
+    NeedBlank,
+
+    /// We have not yet found a header, and are ready for one. This is the
+    /// starting (top-of-file) state, and is re-entered after a blank line if a
+    /// header has not been found.
+    ReadyForHeader,
+
+    /// We have found the first line of the header and the next must be the SPDX
+    /// line.
+    NeedSpdx,
+
+    /// We have found the first and SPDX line and now need a copyright line.
+    NeedCopyright,
+
+    /// We have found at least one copyright and are now waiting for the header
+    /// to end.
+    WaitForEnd,
+
+    /// The complete header (with or without errors) has been found, and we do
+    /// not need to continue processing this file.
+    Done,
+}
+
+fn check_file(cache: &Cache, path: &Path) -> Vec<ErrorInfo> {
+    use LicenseError::*;
+    use LineContents::*;
+    use State::*;
+
+    let mut license_errors = vec![];
+    let mut parser = match Parser::new(cache, path) {
+        Err(ParseError::Binary) => return vec![],
+        Err(error) => panic!("{}: {}", path.display(), error),
+        Ok(parser) => parser,
+    };
+    let mut line_num = 0;
+    let mut state = ReadyForHeader;
+    while state != Done {
+        line_num += 1;
+        let line_contents = match parser.next() {
+            Err(ParseError::Binary) => return vec![],
+            // Coerce end-of-file into Other, as they are treated identically.
+            Err(ParseError::Eof) => Other,
+            Err(error) => panic!("Parse error at {}:{}: {}", path.display(), line_num, error),
+            Ok(contents) => contents,
+        };
+        let (new_state, error) = match (state, line_contents) {
+            (NeedBlank, Comment(_)) => (NeedBlank, None),
+            (NeedBlank, Whitespace) => (ReadyForHeader, None),
+            (NeedBlank, Other) => (Done, Some(Missing)),
+            (ReadyForHeader, Comment(comment)) if !is_first(comment) => (NeedBlank, None),
+            (ReadyForHeader, Comment(comment)) if comment == LICENSED_LINE => (NeedSpdx, None),
+            (ReadyForHeader, Comment(_)) => (NeedSpdx, Some(WrongFirst)),
+            (ReadyForHeader, Whitespace) => (ReadyForHeader, None),
+            (ReadyForHeader, Other) => (Done, Some(Missing)),
+            (NeedSpdx, Comment(comment)) if comment == SPDX_LINE => (NeedCopyright, None),
+            (NeedSpdx, Comment(comment)) if is_spdx(comment) => (NeedCopyright, Some(WrongSpdx)),
+            (NeedSpdx, _) => (Done, Some(MissingSpdx)),
+            (NeedCopyright, Comment(comment)) if is_copyright(comment) => (WaitForEnd, None),
+            (NeedCopyright, _) => (Done, Some(MissingCopyright)),
+            (WaitForEnd, Comment(comment)) if is_copyright(comment) => (WaitForEnd, None),
+            (WaitForEnd, Whitespace) => (Done, None),
+            (WaitForEnd, _) => (Done, Some(MissingBlank)),
+            (Done, _) => unreachable!("Loop didn't end at EOF"),
+        };
+        state = new_state;
+        if let Some(error) = error {
+            license_errors.push(ErrorInfo {
+                file: path.to_owned(),
+                line_num,
+                error,
+            });
+        }
+    }
+    license_errors
+}
+
+fn main() {
+    let cache = &Cache::default();
+    let fs_walk = WalkBuilder::new("./")
+        .add_custom_ignore_filename(".lcignore")
+        .git_exclude(false)
+        .git_global(false)
+        .hidden(false)
+        .require_git(false)
+        .build();
+
+    let mut failed = false;
+    for result in fs_walk {
+        let dir_entry = result.expect("Directory walk failed");
+        let file_type = dir_entry.file_type().expect("File type read failed");
+        if !file_type.is_file() {
+            continue;
+        }
+        for error_info in check_file(cache, dir_entry.path()) {
+            failed = true;
+            eprintln!(
+                "{}:{}: {}",
+                error_info.file.display(),
+                error_info.line_num,
+                error_info.error
+            );
+        }
+    }
+
+    if !failed {
+        println!("License check passed.");
+        return;
+    }
+    exit(1);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn many_errors() {
+        assert_eq!(
+            check_file(&Cache::default(), Path::new("testdata/many_errors.rs")),
+            [
+                ErrorInfo {
+                    file: "testdata/many_errors.rs".into(),
+                    line_num: 1,
+                    error: LicenseError::WrongFirst,
+                },
+                ErrorInfo {
+                    file: "testdata/many_errors.rs".into(),
+                    line_num: 2,
+                    error: LicenseError::WrongSpdx,
+                },
+                ErrorInfo {
+                    file: "testdata/many_errors.rs".into(),
+                    line_num: 5,
+                    error: LicenseError::MissingBlank,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn missing() {
+        assert_eq!(
+            check_file(&Cache::default(), Path::new("testdata/error_missing.rs")),
+            [ErrorInfo {
+                file: "testdata/error_missing.rs".into(),
+                line_num: 1,
+                error: LicenseError::Missing
+            }]
+        );
+    }
+
+    #[test]
+    fn missing_copyright() {
+        assert_eq!(
+            check_file(&Cache::default(), Path::new("testdata/no_copyright.rs")),
+            [ErrorInfo {
+                file: "testdata/no_copyright.rs".into(),
+                line_num: 3,
+                error: LicenseError::MissingCopyright
+            }]
+        );
+    }
+
+    #[test]
+    fn missing_spdx() {
+        assert_eq!(
+            check_file(&Cache::default(), Path::new("testdata/no_spdx.rs")),
+            [ErrorInfo {
+                file: "testdata/no_spdx.rs".into(),
+                line_num: 2,
+                error: LicenseError::MissingSpdx
+            }]
+        );
+    }
+
+    /// Run check_file on a file that should have a valid header. Note this file
+    /// has a shebang line, so it will have to search past the first line to
+    /// find the header.
+    #[test]
+    fn successful() {
+        assert_eq!(
+            check_file(&Cache::default(), Path::new("testdata/by_first_line")),
+            []
+        );
+    }
+}

--- a/tools/license-checker/src/parser.rs
+++ b/tools/license-checker/src/parser.rs
@@ -1,0 +1,300 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022
+// Copyright Google LLC 2022
+
+//! A partial parser that parses source code files *just well enough* to find
+//! license headers.
+//!
+//! `Parser` needs some slow-to-initialize resources, so each `Parser` must be
+//! initialized with a reference to a `Cache` instance.
+
+// It is not obvious how we should handle having multiple comments on one line,
+// e.g.:
+//
+//     /* Comment A */ /* Comment B */ // Comment C
+//
+// To avoid answering that question, this parser only recognizes line comments.
+// That effectively requires license headers to be before any block comments. If
+// that is an issue, we can adapt this parser to read block comments as well.
+
+use std::fs::File;
+use std::io::{self, BufRead, BufReader, ErrorKind};
+use std::path::Path;
+use std::str::FromStr;
+use syntect::easy::ScopeRangeIterator;
+use syntect::highlighting::ScopeSelector;
+use syntect::parsing::{ParseState, ParsingError, ScopeError, ScopeStack, SyntaxSet};
+
+pub struct Cache {
+    is_comment: ScopeSelector,
+    is_punctuation: ScopeSelector,
+    syntax_set: SyntaxSet,
+}
+
+impl Default for Cache {
+    fn default() -> Self {
+        const COMMENT_SELECTOR: &str = "comment.line - comment.line.documentation";
+        Self {
+            is_comment: ScopeSelector::from_str(COMMENT_SELECTOR).unwrap(),
+            is_punctuation: ScopeSelector::from_str("punctuation").unwrap(),
+            syntax_set: SyntaxSet::load_defaults_newlines(),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ParseError {
+    /// Returned when we discover the file is binary (not valid UTF-8)
+    #[error("binary file")]
+    Binary,
+
+    /// Returned at the end of the file.
+    #[error("end-of-file")]
+    Eof,
+
+    #[error("bad byte span")]
+    BadSpan,
+
+    #[error("io error {0}")]
+    IoError(#[from] io::Error),
+
+    #[error("parse error {0}")]
+    ParsingError(#[from] ParsingError),
+
+    #[error("scope error {0}")]
+    ScopeError(#[from] ScopeError),
+}
+
+impl PartialEq for ParseError {
+    fn eq(&self, rhs: &Self) -> bool {
+        use ParseError::*;
+        match (self, rhs) {
+            (Binary, Binary) => true,
+            (Eof, Eof) => true,
+            (BadSpan, BadSpan) => true,
+            _ => false,
+        }
+    }
+}
+
+/// Indicates what a particular line of source code contains.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum LineContents<'l> {
+    /// This line of code consists only of whitespace and comments. The
+    /// contained string slice points to the contents of the comment with
+    /// whitespace trimmed away.
+    Comment(&'l str),
+
+    /// This line only contains whitespace.
+    Whitespace,
+
+    /// This line contains something that is not a comment or whitespace.
+    Other,
+}
+
+pub struct Parser<'cache> {
+    cache: &'cache Cache,
+    line: String,
+    parse_state: Option<ParseState>,
+    reader: BufReader<File>,
+    scopes: ScopeStack,
+}
+
+impl<'cache> Parser<'cache> {
+    /// Creates a new `Parser` that reads the specified file. Will return None
+    /// if the file is binary.
+    pub fn new(cache: &'cache Cache, path: &Path) -> Result<Self, ParseError> {
+        let syntax = match cache.syntax_set.find_syntax_for_file(path) {
+            Err(error) if error.kind() == ErrorKind::InvalidData => return Err(ParseError::Binary),
+            Err(error) => return Err(error.into()),
+            Ok(syntax) => syntax,
+        };
+
+        Ok(Self {
+            cache,
+            line: String::new(),
+            parse_state: syntax.map(ParseState::new),
+            reader: BufReader::new(File::open(path)?),
+            scopes: ScopeStack::new(),
+        })
+    }
+
+    /// Parses the next line and returns its contents. Returns None at EOF.
+    pub fn next(&mut self) -> Result<LineContents, ParseError> {
+        self.line.clear();
+        let bytes_read = match self.reader.read_line(&mut self.line) {
+            Err(error) if error.kind() == ErrorKind::InvalidData => return Err(ParseError::Binary),
+            Err(error) => return Err(error.into()),
+            Ok(bytes) => bytes,
+        };
+        if bytes_read == 0 {
+            // End of file.
+            return Err(ParseError::Eof);
+        }
+
+        // Manual comment extraction for file types syntect doesn't recognize.
+        let Some(ref mut parse_state) = self.parse_state else {
+            return Ok(parse_unknown(&self.line));
+        };
+
+        let cache = self.cache;
+        let ops = parse_state.parse_line(&self.line, &cache.syntax_set)?;
+        let mut contents = None;
+        let mut has_comment = false;
+
+        for (byte_span, op) in ScopeRangeIterator::new(&ops, &self.line) {
+            self.scopes.apply(op)?;
+            // Shortcut execution when we've already classified this line.
+            if contents.is_some() {
+                continue;
+            }
+
+            // Syntaxes sometimes push and pop spurious scopes; don't bother
+            // checking the scopes until we have a non-empty span.
+            if byte_span.is_empty() {
+                continue;
+            }
+
+            let scopes = self.scopes.as_slice();
+            let span = self.line.get(byte_span).ok_or(ParseError::BadSpan)?;
+            if cache.is_comment.does_match(scopes).is_none() {
+                if !span.chars().all(char::is_whitespace) {
+                    contents = Some(LineContents::Other);
+                }
+                continue;
+            }
+            has_comment = true;
+            // Skip the comment's punctuation (e.g. "//")
+            if cache.is_punctuation.does_match(scopes).is_some() {
+                continue;
+            }
+
+            contents = Some(LineContents::Comment(span.trim()));
+        }
+
+        Ok(match (contents, has_comment) {
+            (None, false) => LineContents::Whitespace,
+            (None, true) => LineContents::Comment(""),
+            (Some(contents), _) => contents,
+        })
+    }
+}
+
+// Backup parser for file types that syntect doesn't recognize. Strips "# " and
+// "// " comment prefixes and assumes every no-whitespace line is a comment.
+fn parse_unknown(line: &str) -> LineContents {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return LineContents::Whitespace;
+    }
+    LineContents::Comment(if let Some(comment) = trimmed.strip_prefix("# ") {
+        comment
+    } else if let Some(comment) = trimmed.strip_prefix("// ") {
+        comment
+    } else {
+        trimmed
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use LineContents::*;
+
+    // Test function that confirms the parser produces a particular sequence of
+    // LineContents.
+    #[track_caller]
+    fn assert_produces(parser: Result<Parser, ParseError>, sequence: &[LineContents]) {
+        let mut parser = parser.unwrap();
+        for &expected in sequence {
+            assert_eq!(parser.next(), Ok(expected));
+        }
+        assert_eq!(parser.next(), Err(ParseError::Eof));
+    }
+
+    // Test with a file that causes SyntaxSet::find_syntax_for_file to return an
+    // invalid data error (which binary files can cause).
+    #[test]
+    fn binary() {
+        use ParseError::Binary;
+        let binary = Path::new("testdata/binary");
+        let cache = &Cache::default();
+        assert!(matches!(Parser::new(cache, binary), Err(Binary)));
+    }
+
+    // Confirm Parser correctly processes files identified by their shebang
+    // lines if their extension is unknown.
+    #[test]
+    fn by_first_line() {
+        const EXPECTED: &[LineContents] = &[
+            Comment("!/bin/bash"),
+            Whitespace,
+            Comment("Licensed under the Apache License, Version 2.0 or the MIT License."),
+            Comment("SPDX-License-Identifier: Apache-2.0 OR MIT"),
+            Comment("Copyright Tock Contributors 2022"),
+            Comment("Copyright Google LLC 2022"),
+            Whitespace,
+            Other,
+            Other,
+        ];
+        let by_first_line = Path::new("testdata/by_first_line");
+        assert_produces(Parser::new(&Cache::default(), by_first_line), EXPECTED);
+    }
+
+    #[test]
+    fn fallback_parser() {
+        assert_eq!(parse_unknown(" \t "), Whitespace);
+        assert_eq!(parse_unknown("# Hash comment \n"), Comment("Hash comment"));
+        assert_eq!(
+            parse_unknown("// Slashes comment \n"),
+            Comment("Slashes comment")
+        );
+        assert_eq!(parse_unknown("Plain text \n"), Comment("Plain text"));
+    }
+
+    // Test with a file type that syntect doesn't recognize.
+    #[test]
+    fn unknown_file_type() {
+        const EXPECTED: &[LineContents] = &[
+            Comment("Licensed under the Apache License, Version 2.0 or the MIT License."),
+            Comment("SPDX-License-Identifier: Apache-2.0 OR MIT"),
+            Comment("Copyright Tock Contributors 2022"),
+            Comment("Copyright Google LLC 2022"),
+            Whitespace,
+            Comment("Syntect should not be able to recognize this file's type."),
+            Comment("Parser should adapt and automatically strip // and # comment prefixes."),
+        ];
+        let path = Path::new("testdata/source.unknown_file_type");
+        assert_produces(Parser::new(&Cache::default(), path), EXPECTED);
+    }
+
+    // Test Parser with a variety of line types. This also confirms that syntect
+    // can identify a file type by extension.
+    #[test]
+    fn various_line_types() {
+        const EXPECTED: &[LineContents] = &[
+            Comment("Licensed under the Apache License, Version 2.0 or the MIT License."),
+            Comment("SPDX-License-Identifier: Apache-2.0 OR MIT"),
+            Comment("Copyright Tock Contributors 2022"),
+            Comment("Copyright Google LLC 2022"),
+            Whitespace,
+            Comment("Syntect should recognize this file's type by extension."),
+            Whitespace,
+            Other,
+            Comment(""),
+            Whitespace,
+            Other,
+            Other,
+            Comment(""),
+            Whitespace,
+            Other,
+            Other,
+            Whitespace,
+            Whitespace,
+            Other,
+        ];
+        let path = Path::new("testdata/variety.rs");
+        assert_produces(Parser::new(&Cache::default(), path), EXPECTED);
+    }
+}

--- a/tools/license-checker/testdata/.lcignore
+++ b/tools/license-checker/testdata/.lcignore
@@ -1,0 +1,10 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2022
+# Copyright Google LLC 2022
+
+# These files are designed to produce license checker errors.
+/error_missing.rs
+/many_errors.rs
+/no_copyright.rs
+/no_spdx.rs

--- a/tools/license-checker/testdata/binary
+++ b/tools/license-checker/testdata/binary
@@ -1,0 +1,10 @@
+ÿ
+
+Licensed under the Apache License, Version 2.0 or the MIT License.
+Copyright Tock Contributors 2022
+Copyright Google LLC 2022
+SPDX-License-Identifier: Apache-2.0 OR MIT
+
+The first line of this file is invalid UTF-8, which results in
+find_syntax_for_file returning an error. The license checker should treat this
+file as binary.

--- a/tools/license-checker/testdata/by_first_line
+++ b/tools/license-checker/testdata/by_first_line
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2022
+# Copyright Google LLC 2022
+
+echo Syntect should be able to recognize this as a Bash script, even though it \
+     lacks an extension.

--- a/tools/license-checker/testdata/error_missing.rs
+++ b/tools/license-checker/testdata/error_missing.rs
@@ -1,0 +1,7 @@
+//! This test file should result in a "license missing" error, as the tool sees
+//! a doc comment before the license header.
+
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022
+// Copyright Google LLC 2022

--- a/tools/license-checker/testdata/many_errors.rs
+++ b/tools/license-checker/testdata/many_errors.rs
@@ -1,0 +1,7 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License. [*]
+// SPDX-License-Identifier: Apache-2.0 OR MIT [*]
+// Copyright Tock Contributors 2022
+// Copyright Google LLC 2022
+//
+// [*] This file is designed to generate the following errors in the license
+// checker: MissingBlank, WrongFirst, WrongSpdx.

--- a/tools/license-checker/testdata/no_copyright.rs
+++ b/tools/license-checker/testdata/no_copyright.rs
@@ -1,0 +1,8 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Copyright Tock Contributors 2022
+// Copyright Google LLC 2022
+
+// This file should generate a "missing copyright" error with the license
+// checker (the blank line should be interpreted as an early end to the header).

--- a/tools/license-checker/testdata/no_spdx.rs
+++ b/tools/license-checker/testdata/no_spdx.rs
@@ -1,0 +1,8 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022
+// Copyright Google LLC 2022
+
+// This file should generate a "missing spdx line" error in the license checker
+// (the blank line should be interpreted as an early end to the header).

--- a/tools/license-checker/testdata/source.unknown_file_type
+++ b/tools/license-checker/testdata/source.unknown_file_type
@@ -1,0 +1,7 @@
+Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2022
+# Copyright Google LLC 2022
+
+Syntect should not be able to recognize this file's type.
+Parser should adapt and automatically strip // and # comment prefixes.

--- a/tools/license-checker/testdata/variety.rs
+++ b/tools/license-checker/testdata/variety.rs
@@ -1,0 +1,19 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022
+// Copyright Google LLC 2022
+
+// Syntect should recognize this file's type by extension.
+
+/// Single-line doc comment. The next line is a comment with no contents.
+//
+
+/* Multi-line comment. The next comment contains only whitespace.
+ */
+//     
+
+/** Multi-line doc comment. The line after this comment contains whitespace.
+  */
+    
+
+#![rustfmt::skip]  // This line should be considered "other" (i.e. code)


### PR DESCRIPTION
# Pull Request Overview

This pull request adds an easy-to-use Bash-like command history for the process console.

# Added features

   - User can enable/disable the command history from the board's `main.rs`.
   - If enabled, user can scroll `up` or `down` by pressing `up` and `down` arrow keys respectively.
   - Pressing on accident `up` or `down` arrow saves the unfinished command and can be fetched back by going to the bottom of command history. 
   - Modifying a command from history is also saved (if accidentally pressed `up` or `down` arrow).
   - Empty commands (whitespace-filled) don't get registered in the command history.
   - Invalid commands also are saved into the history structure.

# Code size for IMIX binary build with enabled/disabled command history:

| Build | .text | .data | .bss | .dec |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| Tock master  | 174468  |  0 |  29592  | 204060  |
| Enabled with default size  | 175492  |  0  |  28944  |  204436  |
| Disabled  |  174292  | 0  |  28576  |  202868  |

# Testing Strategy

The implementation of the command history was tested on the `nrf52840dk` and `esp32-c3-devkitM-1` boards.

# Files changed
`capsules/process_console.rs`
 ~ implementation for command history

`boards/components/process_console.rs`
 ~ added a new branch to process_console_component_static macro for easily enable/disable the command history

# Documentation Updated

Updated the documentation in `doc/Process_Console.md` accordingly : 
- Code support on how to enable/disable the command history
- How to use command history
- Support for selecting a custom size for the command history

# Formatting 
- [x] Ran `make prepush`